### PR TITLE
Support recent elm-css versions

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,10 +11,7 @@
     ],
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "elm-lang/html": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/elm-css": "7.0.0 <= v < 8.0.0",
-        "rtfeldman/elm-css-helpers": "2.0.1 <= v < 3.0.0",
-        "scottcorgan/elm-html-template": "1.0.1 <= v < 2.0.0"
+        "rtfeldman/elm-css": "7.0.0 <= v < 10.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -1,17 +1,17 @@
 module Examples.Main exposing (..)
 
-import Html exposing (..)
-import Html.Template
-import Html.CssHelpers
-import Css.File
+import Css
 import Css.Reset
+import Html exposing (..)
+import Html.CssHelpers
+import Html.Template
 
 
 main : Program Never {} b
 main =
     Html.beginnerProgram
         { model = {}
-        , update = (\_ _ -> {})
+        , update = \_ _ -> {}
         , view = view
         }
 
@@ -19,7 +19,8 @@ main =
 compiledCss : String
 compiledCss =
     Css.Reset.css
-        |> Css.File.compile
+        |> List.singleton
+        |> Css.compile
         |> .css
 
 

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        ".", "../src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/elm-css-helpers": "2.0.1 <= v < 3.0.0",
+        "scottcorgan/elm-html-template": "1.0.1 <= v < 2.0.0",
+        "rtfeldman/elm-css": "9.0.0 <= v < 10.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/src/Css/Reset.elm
+++ b/src/Css/Reset.elm
@@ -3,35 +3,34 @@ module Css.Reset exposing (css, snippets)
 {-| This library is mostly a direct port of [normalize.css](https://github.com/necolas/normalize.css).
 Compile it with your elm-css code to have easier cross-browser styling experience.
 
+
 # Normalizing CSS Stylesheet
+
 @docs css
 
+
 # Css Snippets
+
 @docs snippets
 
 -}
 
 import Css exposing (..)
-import Css.Elements exposing (..)
+import Css.Elements as Element exposing (..)
 
 
 {-| A [Stylesheet](https://github.com/rtfeldman/elm-css/blob/master/Tutorial.md) to rest values to make them more consistent across most browsers. You can
 include this stylesheet in your elm-css compilation file.
 
-    port module Stylesheets exposing (..)
-
-    import String
-
     import Css exposing (..)
     import Css.File exposing (..)
+    import Css.Reset
     import Html exposing (div)
     import Html.App as Html
-
-    import Css.Reset
     import My.Styles
+    import String
 
     port files : CssFileStructure -> Cmd msg
-
 
     styles : List Css.Stylesheet
     styles =
@@ -39,31 +38,32 @@ include this stylesheet in your elm-css compilation file.
         , My.Styles.css
         ]
 
-
     cssFiles : CssFileStructure
     cssFiles =
-        toFileStructure [ ("dist/styles.css", compileMany styles) ]
+        toFileStructure [ ( "dist/styles.css", compileMany styles ) ]
+
 
     {- Helper function to compile many stylesheets -}
-    compileMany : List Css.Stylesheet -> { warnings: List String, css: String }
+
+    compileMany : List Css.Stylesheet -> { warnings : List String, css : String }
     compileMany styles =
         let
             results =
                 List.map Css.compile styles
         in
-            { warnings = List.concatMap .warnings results
-            , css = String.join "\n\n" (List.map .css results)
-            }
-
+        { warnings = List.concatMap .warnings results
+        , css = String.join "\n\n" (List.map .css results)
+        }
 
     main : Program Never
     main =
         Html.program
             { init = ( (), files cssFiles )
-            , view = \_ -> (div [] [])
+            , view = \_ -> div [] []
             , update = \_ _ -> ( (), Cmd.none )
             , subscriptions = \_ -> Sub.none
             }
+
 -}
 css : Stylesheet
 css =
@@ -73,8 +73,6 @@ css =
 {-| The snippets used to generate the normalizing stylesheet. Use this if you want to append
 these to your own style sheet. This is useful if you prefer to use inline styles over
 generator a stylesheet with the [elm-css preprocessor](https://www.npmjs.com/package/elm-css)
-
-    module MyModule exposing (..)
 
     import Css exposing (..)
     import Css.Elements exposing (..)
@@ -89,6 +87,7 @@ generator a stylesheet with the [elm-css preprocessor](https://www.npmjs.com/pac
                 [ everything
                     [ boxSizing borderBox ]
                 ]
+
 -}
 snippets : List Snippet
 snippets =
@@ -145,7 +144,7 @@ snippets =
         , form
         , label
         , legend
-        , table
+        , Element.table
         , caption
         , tbody
         , tfoot
@@ -200,7 +199,7 @@ snippets =
         [ property "content" ""
         , property "content" "none"
         ]
-    , table
+    , Element.table
         [ property "border-collapse" "collapse"
         , property "border-spacing" "0"
         ]


### PR DESCRIPTION
- [x] separate elm-package.json for the example
- [x] widen constraint on `elm-css` to include current release
- [x] fix example for current elm-css version